### PR TITLE
Add embed mode for servo.org about page

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -9,6 +9,23 @@
             body {
                 font-size: 26px;
             }
+
+            html.embed {
+                background: #121619;
+                color: #f5f5f5;
+            }
+            html.embed * {
+                /* simple-grid has a *{color} rule */
+                color: revert;
+            }
+            html.embed .google-visualization-tooltip {
+                background: #121619;
+                color: #f5f5f5;
+            }
+            html.embed .hide-in-embed {
+                display: none;
+            }
+
             #selected-area {
                 padding: 10px;
             }
@@ -50,7 +67,7 @@
     </head>
     <body>
         <div class="container">
-            <div class="row">
+            <div class="row hide-in-embed">
                 <div class="col-4"></div>
                 <div class="col-4">
                     <img id="logo" height="100"
@@ -68,7 +85,7 @@
                 <div class="col-3"></div>
             </div>
             <div id="servo-chart"></div>
-            <div class="row">
+            <div class="row hide-in-embed">
                 <div class="col-4"></div>
                 <div class="col-4" id="show-legacy-div">
                     <input type="checkbox" name="show-legacy" id="show-legacy"></input>
@@ -76,7 +93,7 @@
                 </div>
                 <div class="col-4"></div>
             </div>
-            <div class="row">
+            <div class="row hide-in-embed">
                 <table class="col-12" id="score-table">
                     <thead id="score-table-header">
                     </thead>

--- a/site/load-chart.js
+++ b/site/load-chart.js
@@ -4,6 +4,11 @@ google.charts.load('current', { packages: ['corechart', 'line'] })
 google.charts.setOnLoadCallback(setupChart)
 
 const fetchData = fetch('scores.json')
+const embed = location.search == "?embed"
+
+if (embed) {
+    document.documentElement.classList.add("embed")
+}
 
 function formatDate (date) {
     const months = [
@@ -40,19 +45,30 @@ function setupChart () {
     const options = {
         height: 350,
         fontSize: 16,
-        legend: { position: 'top' },
+        legend: {
+            position: 'top',
+            ...(embed ? {
+                textStyle: { color: '#f5f5f5' }
+            } : {})
+        },
         hAxis: {
             format: 'MMM-YYYY',
             viewWindow: {
                 max: maxDate
-            }
+            },
+            ...(embed ? {
+                textStyle: { color: '#f5f5f5' }
+            } : {})
         },
         vAxis: {
             format: 'percent',
             viewWindow: {
                 min: 0,
                 max: 1
-            }
+            },
+            ...(embed ? {
+                textStyle: { color: '#f5f5f5' }
+            } : {})
         },
         explorer: {
             actions: ['dragToZoom', 'rightClickToReset'],
@@ -61,9 +77,13 @@ function setupChart () {
             maxZoomIn: 4.0
         },
         tooltip: {
+            // textStyle has no effect if isHtml is true
             isHtml: true,
             trigger: 'both'
-        }
+        },
+        ...(embed ? {
+            backgroundColor: '#121619'
+        } : {})
     }
 
     const node = document.getElementById('servo-chart')


### PR DESCRIPTION
This patch adds a simplified version of the dashboard for embedding in [our about page](https://servo.org/about/), with just the focus area field and the chart, by navigating to [?embed](https://wpt.servo.org/?embed).

![image](https://github.com/servo/internal-wpt-dashboard/assets/465303/29712a89-4aa4-47fe-9838-d2ce15e7f7f7)