### PR TITLE
Fix include.ini used for 2020 layout

### DIFF
--- a/.github/workflows/run-wpt.yml
+++ b/.github/workflows/run-wpt.yml
@@ -49,10 +49,6 @@ jobs:
           echo Downloaded $SERVO_VERSION
           echo "SERVO_VERSION=$SERVO_VERSION" >> $GITHUB_ENV
         working-directory: servo
-      - name: Override include.ini
-        if: ${{ inputs.layout-engine == '2020' }}
-        run: cp tests/wpt/include-legacy-layout.ini tests/wpt/include.ini
-        working-directory: servo
       - name: Run tests
         run: |
           python3 ./mach test-wpt \

--- a/.github/workflows/run-wpt.yml
+++ b/.github/workflows/run-wpt.yml
@@ -28,13 +28,22 @@ jobs:
         with:
           repository: servo/servo
           path: servo
+      - name: Cache libffi
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: ./libffi6_3.2.1-8_amd64.deb
+          key: cache-libffi
+      - name: Download libffi
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          wget http://mirrors.kernel.org/ubuntu/pool/main/libf/libffi/libffi6_3.2.1-8_amd64.deb
       - name: Prep test environment
         run: |
           python3 -m pip install --upgrade pip virtualenv
           sudo apt update
           sudo apt install -qy --no-install-recommends libgl1 libssl1.1 libdbus-1-3 libxcb-xfixes0-dev libxcb-shape0-dev libunwind8 libegl1-mesa
           sudo apt install -qy libgstreamer1.0-0 libgstreamer-gl1.0-0 libgstreamer-plugins-bad1.0-0
-          wget http://mirrors.kernel.org/ubuntu/pool/main/libf/libffi/libffi6_3.2.1-8_amd64.deb
           sudo apt install ./libffi6_3.2.1-8_amd64.deb
       - name: Download latest nightly
         run: |


### PR DESCRIPTION
Servo repo now has single include.ini for both 2013 and 2020 layout engines.
Also includes a fix for frequent timeouts from kernel.org when fetching libffi deb file.
