### PR TITLE
extend the chart to display results for 2024

### DIFF
--- a/site/load-chart.js
+++ b/site/load-chart.js
@@ -36,7 +36,7 @@ function toolTip (date, wpt_sha, servo_version, score, engine) {
 }
 
 function setupChart () {
-    const endOfYear = new Date(2023, 11, 31)
+    const endOfYear = new Date(2024, 11, 31)
     let maxDate = new Date()
     if (maxDate > endOfYear) {
         maxDate = endOfYear


### PR DESCRIPTION
The dashboard was inspired by the WPT.fyi Interop dashboard which groups charts by year. For Servo, we have decided to extend the existing chart for this year. The backend still generates data for 2024, only the frontend needs to change.