### PR TITLE
Use `Object.hasOwn` to handle subtests with names like `toString`

### DIFF
--- a/process-wpt-results.js
+++ b/process-wpt-results.js
@@ -193,7 +193,7 @@ export function score_run (run, against_run, focus_areas_map) {
         } else {
             let test_score = 0
             for (const subtest of subtest_names) {
-                if (run_test.subtests[subtest]) {
+                if (Object.hasOwn(run_test.subtests, subtest)) {
                     test_score += run_test.subtests[subtest].score
                 }
             }

--- a/test/process-wpt-results.test.js
+++ b/test/process-wpt-results.test.js
@@ -206,6 +206,39 @@ describe('Scoring', () => {
         const score = score_run(run, run, { test1: ['all'] })
         assert.equal(score.all, 333)
     })
+    it('calculates scores correctly even subtest name collides with JS builtins', () => {
+        const run = {
+            test_scores: {
+                test1: {
+                    score: 0,
+                    subtests: {
+                    }
+                },
+                test2: {
+                    score: 1,
+                    subtests: { }
+                }
+            }
+        }
+
+        const against_run = {
+            test_scores: {
+                test1: {
+                    score: 1,
+                    subtests: {
+                        toString: { score: 1 }
+                    }
+                },
+                test2: {
+                    score: 1,
+                    subtests: { }
+                }
+            }
+        }
+
+        const score = score_run(run, against_run, { test1: ['all'], test2: ['all'] })
+        assert.equal(score.all, 500)
+    })
     it('calculates scores based only on tests in new runs', () => {
         const old_run = {
             test_scores: {


### PR DESCRIPTION
This fixes a bug where subtest names like `toString` that are defined on the prototype (e.g `Function.toString`) makes the logic take the branch that corresponds to the existence of scores for that subtest. This causes any subsequent property lookups to be `undefined` which then gets transformed to NaN and propagates to the final scores.