### PR TITLE
Fix text on the chart replace "all time" by "since April 2023"

### DIFF
--- a/site/load-chart.js
+++ b/site/load-chart.js
@@ -11,7 +11,7 @@ const periodRanges = {
     'last 3 months': 3,
     'last 6 months': 6,
     'last year': 12,
-    'all time': null
+    'since April 2023': null
 }
 
 if (embed) {


### PR DESCRIPTION
We only have data since April 2023, so "all time" label was misleading. If we ever add more data from before that time, we should update the label accordingly.