### PR TITLE
drop support for tracking legacy layout

### DIFF
--- a/.github/workflows/update-scores.yml
+++ b/.github/workflows/update-scores.yml
@@ -17,12 +17,6 @@ env:
   SHELL: /bin/bash
 
 jobs:
-  wpt-for-layout-2013:
-    uses: ./.github/workflows/run-wpt.yml
-    with:
-      layout-engine: 2013
-      artifact-name: wpt-chunks
-
   wpt-for-layout-2020:
     uses: ./.github/workflows/run-wpt.yml
     with:
@@ -33,19 +27,13 @@ jobs:
     name: Process all chunks and update metrics
     runs-on: ubuntu-22.04
     needs:
-      - wpt-for-layout-2013
       - wpt-for-layout-2020
     steps:
       - name: Checkout dashboard repo
         uses: actions/checkout@v3
         with:
           ref: main
-      - name: Download wpt results for 2013
-        uses: actions/download-artifact@v3
-        with:
-          name: wpt-chunks
-          path: wpt-chunks
-      - name: Download wpt results for 2020
+      - name: Download wpt results for layout 2020
         uses: actions/download-artifact@v3
         with:
           name: wpt-chunks-2020
@@ -57,12 +45,10 @@ jobs:
       - name: Process new test results
         run: |
           CURRENT_DATE=$(date +"%Y-%m-%d")
-          mkdir -p runs
           mkdir -p runs-2020
-          node index.js --add wpt-chunks wpt-chunks-2020 "$CURRENT_DATE"
+          node index.js --add wpt-chunks-2020 "$CURRENT_DATE"
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git add runs/${CURRENT_DATE}.xz
           git add runs-2020/${CURRENT_DATE}.xz
           git commit -m "Add runs for $CURRENT_DATE"
           git push

--- a/index.js
+++ b/index.js
@@ -107,25 +107,12 @@ async function main () {
     }
 
     if (mode === '--add') {
-        const chunks_2013 = process.argv[3]
-        const chunks_2020 = process.argv[4]
-        const date = process.argv[5]
-        await add_run('runs', chunks_2013, date)
-        await add_run('runs-2020', chunks_2020, date)
+        const chunks = process.argv[3]
+        const date = process.argv[4]
+        await add_run('runs-2020', chunks, date)
     }
 
-    const scores_2013 = await recalc_scores('runs')
-    const scores_2020 = await recalc_scores('runs-2020')
-    const scores_by_date = new Map(scores_2020.map(score => [score[0], score]))
-
-    const scores = []
-    for (const score_2013 of scores_2013) {
-        const len = scores.push(score_2013)
-        if (scores_by_date.has(score_2013[0])) {
-            const score_2020 = scores_by_date.get(score_2013[0]).slice(1)
-            scores[len - 1].splice(score_2013.length, 0, ...score_2020)
-        }
-    }
+    const scores = await recalc_scores('runs-2020')
 
     const { area_keys, area_names: focus_areas } = get_focus_areas()
 

--- a/site/index.html
+++ b/site/index.html
@@ -110,14 +110,6 @@
             </div>
             <div id="servo-chart"></div>
             <div class="row hide-in-embed">
-                <div class="col-4"></div>
-                <div class="col-4" id="show-legacy-div">
-                    <input type="checkbox" name="show-legacy" id="show-legacy"></input>
-                    <label for="show-legacy">Show Legacy Layout</label>
-                </div>
-                <div class="col-4"></div>
-            </div>
-            <div class="row hide-in-embed">
                 <table class="col-12" id="score-table">
                     <thead id="score-table-header">
                     </thead>

--- a/site/load-chart.js
+++ b/site/load-chart.js
@@ -105,8 +105,8 @@ function setupChart () {
     const node = document.getElementById('servo-chart')
     const area_dropdown = document.getElementById('selected-area')
     const period_dropdown = document.getElementById('selected-period')
-    const show_legacy = document.getElementById('show-legacy')
     const chart = new google.visualization.LineChart(node)
+    const AREA_SCORE_OFFSET = 3
     let all_scores
 
     Object.keys(periodRanges).forEach(date => {
@@ -122,8 +122,6 @@ function setupChart () {
         const chosen_period = period_dropdown.value
         const area_index = all_scores.area_keys.indexOf(chosen_area)
         const table = new google.visualization.DataTable()
-        const stride = all_scores.area_keys.length
-        const legacy_layout = show_legacy.checked
         options.series = []
         const monthsToSubtract = periodRanges[chosen_period]
         const minDate = monthsToSubtract
@@ -132,44 +130,22 @@ function setupChart () {
 
         table.addColumn('date', 'runOn')
 
-        if (legacy_layout) {
-            options.series.push({ color: '#DC3912' })
-            table.addColumn('number', 'Legacy Layout')
-            table.addColumn({ type: 'string', role: 'tooltip', p: { html: true } })
-        }
-
         options.series.push({ color: '#3366CC' })
         table.addColumn('number', 'Servo Layout')
         table.addColumn({ type: 'string', role: 'tooltip', p: { html: true } })
 
-        for (const s of all_scores.scores) {
-            const score_2013 = s[area_index + 3]
-            const score_2020 = s[stride + area_index + 5]
-            const date = parseDateString(s[0])
+        for (const scores_for_run of all_scores.scores) {
+            const area_score = scores_for_run[area_index + AREA_SCORE_OFFSET]
+            const [date_string, wpt_sha, browser_version] = scores_for_run
+            const date = parseDateString(date_string)
             if (date < minDate) {
                 continue
             }
             const row = [
-                date
+                date,
+                area_score / 1000,
+                toolTip(date, wpt_sha, browser_version, area_score, 'Servo Layout')
             ]
-
-            if (legacy_layout) {
-                row.push(
-                    score_2013 / 1000,
-                    toolTip(date, s[1], s[2], score_2013, 'Legacy Layout')
-                )
-            }
-
-            if (score_2020 !== undefined) {
-                const wpt_sha = s[stride + 3]
-                const version = s[stride + 4]
-                row.push(
-                    score_2020 / 1000,
-                    toolTip(date, wpt_sha, version, score_2020, 'Servo Layout')
-                )
-            } else {
-                row.push(undefined, undefined)
-            }
             table.addRow(row)
         }
         chart.draw(table, options)
@@ -184,7 +160,6 @@ function setupChart () {
 
     function update_table (scores) {
         const score_table = document.getElementById('score-table-body')
-        const legacy = (value) => show_legacy.checked ? value : ''
         removeChildren(score_table)
 
         removeChildren(document.getElementById('score-table-header'))
@@ -192,20 +167,17 @@ function setupChart () {
                 'beforeend',
                 `<tr>
                     <th>Test Suite</th>
-                    ${legacy('<th>Legacy Layout</th>')}
                     <th>Servo Layout</th>
                 </tr>`
             )
 
         for (const [idx, area] of scores.area_keys.entries()) {
             const recent_score = scores.scores[scores.scores.length - 1]
-            const stride = scores.area_keys.length
             score_table.insertAdjacentHTML(
                 'beforeend',
                 `<tr class="${idx % 2 ? 'odd' : 'even'}">
                     <td>${scores.focus_areas[area]}</td>
-                    ${legacy(`<td class="score">${String(recent_score[idx + 3] / 10).padEnd(4, '.0')}%</td>`)}
-                    <td class="score">${String(recent_score[stride + idx + 5] / 10).padEnd(4, '.0')}%</td>
+                    <td class="score">${String(recent_score[idx + AREA_SCORE_OFFSET] / 10).padEnd(4, '.0')}%</td>
                 </tr>`
             )
         }
@@ -235,7 +207,6 @@ function setupChart () {
 
             area_dropdown.onchange = update
             period_dropdown.onchange = update
-            show_legacy.onchange = update
             area_dropdown.value = scores.area_keys[1]
             period_dropdown.value = Object.keys(periodRanges)[4]
             update()


### PR DESCRIPTION
After [servo/servo#34290][1], our nightly builds no longer support legacy layout. Continuing support for legacy layout in the dashboard would require a custom build of servo. We considered displaying the existing 'legacy layout' scores (the line in the chart would end earlier than non-legacy layout), but that would require more changes in the code and still won't help with the table of latest scores below the chart. Hence, since the [plan][2] was to sunset legacy layout anyway, this change drops support for tracking legacy layout pass rates.

[1]: https://github.com/servo/servo/pull/34290
[2]: https://github.com/servo/project/blob/main/governance/tsc/tsc-2023-09-07.md#plan-regarding-legacy-layout-engine