### PR TITLE
Upgrade to latest actions for deploying the site

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,9 +39,9 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: 'site'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
upload-pages-artifact@v2 uses v3 of upload-artifact which is now deprecated, causing the build to fail with the message

```
This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```

This patch upgrades the workflow to use the latest version of `upload-pages-artifact`. The related `deploy-pages` action also needs to be upgrade as per the release notes:

https://github.com/actions/upload-pages-artifact/releases/tag/v3.0.0