### PR TITLE
upgrade github actions in run-wpt and update-score workflows

### DIFF
--- a/.github/workflows/run-wpt.yml
+++ b/.github/workflows/run-wpt.yml
@@ -63,8 +63,8 @@ jobs:
             --total-chunks ${{ env.max_chunk_id }}
         working-directory: servo
       - name: Archive the wpt result chunk
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.artifact-name }} 
+          name: ${{ inputs.artifact-name }}-${{ matrix.chunk_id }}
           path: servo/wpt-report-${{ matrix.chunk_id }}.json
 

--- a/.github/workflows/update-scores.yml
+++ b/.github/workflows/update-scores.yml
@@ -34,10 +34,11 @@ jobs:
         with:
           ref: main
       - name: Download wpt results for layout 2020
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: wpt-chunks-2020
           path: wpt-chunks-2020
+          pattern: wpt-chunks-2020-*
+          merge-multiple: true
       - uses: actions/setup-node@v3
         with:
           node-version: 16
@@ -55,9 +56,9 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: 'site'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
upload-artifact@v4 has a breaking change - It no longer merges artifacts from matrix jobs, and requires them to have different names. download-artifact@v4 has new input parameters that allow us to perform the merge manually upon downloading.

Test run: https://github.com/mukilan/internal-wpt-dashboard/actions/runs/13069572274