### PR TITLE
Track tests in `/css/css-sizing/`

### DIFF
--- a/process-wpt-results.js
+++ b/process-wpt-results.js
@@ -121,9 +121,9 @@ const FOCUS_AREAS = {
         predicate: prefix_predicate('/css/cssom/'),
         order: 91
     },
-    csspos: {
-        name: '/css/css-position',
-        predicate: prefix_predicate('/css/css-position/'),
+    cssalign: {
+        name: '/css/css-align',
+        predicate: prefix_predicate('/css/css-align/'),
         order: 92
     },
     cssflex: {
@@ -136,10 +136,15 @@ const FOCUS_AREAS = {
         predicate: prefix_predicate('/css/css-grid/'),
         order: 94
     },
-    cssalign: {
-        name: '/css/css-align',
-        predicate: prefix_predicate('/css/css-align/'),
+    csspos: {
+        name: '/css/css-position',
+        predicate: prefix_predicate('/css/css-position/'),
         order: 95
+    },
+    csssizing: {
+        name: '/css/css-sizing',
+        predicate: prefix_predicate('/css/css-sizing/'),
+        order: 95.5
     },
     csstext: {
         name: '/css/css-text',


### PR DESCRIPTION
It's good to see the progress with sizing keywords, and will also be useful in the future when implementing `aspect-ratio` on all elements. Also sorting alphabetically while I'm at it.

Graph for `/css/css-sizing/`:
![](https://github.com/user-attachments/assets/7cf668bf-d83c-4f25-99dd-151ee8557538)