### PR TITLE
Add information about number of tests and subtests

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,6 +113,7 @@ async function main () {
     }
 
     const scores = await recalc_scores('runs-2020')
+    const scores_last_run = scores[scores.length - 1]
 
     const { area_keys, area_names: focus_areas } = get_focus_areas()
 
@@ -120,6 +121,9 @@ async function main () {
     await mkdir('./site', { recursive: true })
     write_json_file(
         './site/scores.json', { area_keys, focus_areas, scores })
+    console.log('Writing site/scores-last-run.json')
+    write_json_file(
+        './site/scores-last-run.json', { area_keys, focus_areas, scores_last_run })
 
     console.log('Done')
 }


### PR DESCRIPTION
Add information about number of tests and subtests

This modifies the scores.json file so it now provides more data:
* total_tests: The total number of tests
* total_score: The total scores for the tests
* total_subtests: The total number of subtests
* total_subtests_passed: The number of subtests that pass

This is based on previous work by Delan Azabani at #35.

This also creates a new output file scores-last-run.json
with only the data of the last run.
