### PR TITLE
Use object rather than array for `scores.json` entries

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ async function add_run (runs_dir, chunks_dir, date) {
 async function recalc_scores (runs_dir) {
     console.log(`Calculating scores for ${runs_dir} directory...`)
 
-    const scores = []
+    const run_results = []
     console.log('Enumerating runs')
     const all_runs = await all_runs_sorted(runs_dir)
     const run_count = all_runs.length
@@ -91,10 +91,10 @@ async function recalc_scores (runs_dir) {
             scores: score
         }
 
-        scores.push(row)
+        run_results.push(row)
     }
 
-    return scores
+    return run_results
 }
 
 async function main () {
@@ -109,18 +109,18 @@ async function main () {
         await add_run('runs-2020', chunks, date)
     }
 
-    const scores = await recalc_scores('runs-2020')
-    const scores_last_run = scores[scores.length - 1]
+    const run_results = await recalc_scores('runs-2020')
+    const last_run = run_results[run_results.length - 1]
 
     const focus_areas = get_focus_areas()
 
     console.log('Writing site/scores.json')
     await mkdir('./site', { recursive: true })
     write_json_file(
-        './site/scores.json', { focus_areas, scores })
+        './site/scores.json', { focus_areas, runs: run_results })
     console.log('Writing site/scores-last-run.json')
     write_json_file(
-        './site/scores-last-run.json', { focus_areas, scores_last_run })
+        './site/scores-last-run.json', { focus_areas, last_run })
 
     console.log('Done')
 }


### PR DESCRIPTION
This changes the `scores.json` format in preparation for #50 (rewrite score calculation in Rust). The main change is to replace the use of a heterogeneous array (mix of strings and objects) with a keyed object and a nested array. The new format is easier to serialize/deserialize using `serde` (and IMO makes more sense in JS anyway).

Corresponding servo.org PR (should be merged at same time): https://github.com/servo/servo.org/pull/241

before:

```json
[
    "2025-07-17",
    "1c4797809",
    "0.0.1-f70a4eb4f",
    {
      "total_tests": 46787,
      "total_score": 29447.8764608724,
      "total_subtests": 1854463,
      "total_subtests_passed": 1722785
    },
    {
      "total_tests": 809,
      "total_score": 502.872027417027,
      "total_subtests": 3659,
      "total_subtests_passed": 2186
    },
    ...
]
```

After:

```json
{
        "date": "2025-07-17",
        "wpt_revision": "1c4797809",
        "servo_revision": "0.0.1-f70a4eb4f",
        "scores":
        [
            {
                "total_tests": 46787,
                "total_score": 29447.876460872423,
                "total_subtests": 1854463,
                "total_subtests_passed": 1722785
            },
            {
                "total_tests": 809,
                "total_score": 502.8720274170274,
                "total_subtests": 3659,
                "total_subtests_passed": 2186
            },
            ...
        ]
}
```